### PR TITLE
[bugfix][feature] Remove git dependency and support `path` attribute

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,7 @@ provisioner:
   ansible_extra_flags: <%= ENV['ANSIBLE_EXTRA_FLAGS'] %>
   http_proxy: <%= ENV['ANSIBLE_PROXY'] %>
   idempotency_test: true
+  requirements_path: requirements.yml
   additional_copy_path:
     - extra_modules
     - filter_plugins

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ poudriere_config_default:
 | `method` | method to use to create the ports tree | no |
 | `branch` | branch to checkout | no |
 | `extra_flags` | additional flags to `poudriere(8)` when creating ports tree | no |
+| `path` | path to the ports tree | no |
 | `state` | state of the ports, either `present` or `absent` | yes |
 
 ## `poudriere_jails`

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,5 +21,6 @@ galaxy_info:
 
   galaxy_tags:
     - ports
+    - poudriere
 #dependencies:
 #  - { role: username.common, some_parameter: 3 }

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+
+- name: reallyenglish.git

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,11 +24,6 @@
     src: poudriere.conf.j2
     dest: "{{ poudriere_conf }}"
 
-- name: Install git
-  pkgng:
-    name: git
-    state: present
-
 - name: Create hooks
   template:
     src: hook.sh.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,7 +99,7 @@
   with_dict: "{{ poudriere_ports }}"
 
 - name: Create ports tree
-  command: "poudriere ports -c -p {{ item.key }}{% if 'method' in item.value %} -m {{ item.value.method }}{% endif %} {% if 'branch' in item.value %} -B {{ item.value.branch }} {% endif %} {% if 'extra_flags' in item.value %}{{ item.value.extra_flags }}{% endif %}"
+  shell: "poudriere ports -c -p {{ item.key }}{% if 'method' in item.value %} -m {{ item.value.method }}{% endif %} {% if 'branch' in item.value %} -B {{ item.value.branch }}{% endif %} {% if 'path' in item.value %}-F '{{ item.value.path }}'{% endif %} {% if 'extra_flags' in item.value %}{{ item.value.extra_flags }}{% endif %}"
   args:
     creates: "{{ poudriere_config_merged.BASEFS }}/ports/{{ item.key }}"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,7 +99,7 @@
   with_dict: "{{ poudriere_ports }}"
 
 - name: Create ports tree
-  shell: "poudriere ports -c -p {{ item.key }}{% if 'method' in item.value %} -m {{ item.value.method }}{% endif %} {% if 'branch' in item.value %} -B {{ item.value.branch }}{% endif %} {% if 'path' in item.value %}-F '{{ item.value.path }}'{% endif %} {% if 'extra_flags' in item.value %}{{ item.value.extra_flags }}{% endif %}"
+  shell: "poudriere ports -c -p {{ item.key }}{% if 'method' in item.value %} -m {{ item.value.method }}{% endif %} {% if 'branch' in item.value %} -B {{ item.value.branch }}{% endif %} {% if 'path' in item.value %}-M '{{ item.value.path }}'{% endif %} {% if 'extra_flags' in item.value %}{{ item.value.extra_flags }}{% endif %}"
   args:
     creates: "{{ poudriere_config_merged.BASEFS }}/ports/{{ item.key }}"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,7 +99,7 @@
   with_dict: "{{ poudriere_ports }}"
 
 - name: Create ports tree
-  shell: "poudriere ports -c -p {{ item.key }}{% if 'method' in item.value %} -m {{ item.value.method }}{% endif %} {% if 'branch' in item.value %} -B {{ item.value.branch }}{% endif %} {% if 'path' in item.value %}-M '{{ item.value.path }}'{% endif %} {% if 'extra_flags' in item.value %}{{ item.value.extra_flags }}{% endif %}"
+  command: "poudriere ports -c -p {{ item.key }}{% if 'method' in item.value %} -m {{ item.value.method }}{% endif %} {% if 'branch' in item.value %} -B {{ item.value.branch }}{% endif %} {% if 'path' in item.value %}-M '{{ item.value.path }}'{% endif %} {% if 'extra_flags' in item.value %}{{ item.value.extra_flags }}{% endif %}"
   args:
     creates: "{{ poudriere_config_merged.BASEFS }}/ports/{{ item.key }}"
   when:

--- a/tests/integration/build_packages/poudriere.yml
+++ b/tests/integration/build_packages/poudriere.yml
@@ -8,4 +8,5 @@
     no_proxy: "{{ no_proxy | default() }}"
 
   roles:
+    - name: reallyenglish.git
     - ansible-role-poudriere

--- a/tests/integration/build_packages/requirements.yml
+++ b/tests/integration/build_packages/requirements.yml
@@ -1,0 +1,3 @@
+---
+
+- name: reallyenglish.git

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -1,5 +1,6 @@
 - hosts: localhost
   roles:
+    - name: reallyenglish.git
     - ansible-role-poudriere
   vars:
     poudriere_config:

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -16,7 +16,7 @@
         state: present
       vagrant:
         state: present
-        extra_flags: -f none
+        extra_flags: -f none -F
         path: /home/vagrant/freebsd-ports
     poudriere_jails:
       "10_3":

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -14,6 +14,10 @@
         method: git
         branch: 20170222
         state: present
+      vagrant:
+        state: present
+        extra_flags: -f none
+        path: /home/vagrant/freebsd-ports
     poudriere_jails:
       "10_3":
         method: http

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -52,6 +52,7 @@ describe command("poudriere ports -l") do
   quoted = Regexp.escape("#{basefs}/ports/mini")
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/^mini\s+git\s+(?:\d+-\d+-\d+\s+\d+:\d+:\d+\s+)?#{quoted}/) }
+  its(:stdout) { should match(/^vagrant\s+-\s+#{Regexp.escape("/usr/local/poudriere/ports/vagrant")}$/) }
   its(:stderr) { should match(/^$/) }
 end
 

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -52,7 +52,7 @@ describe command("poudriere ports -l") do
   quoted = Regexp.escape("#{basefs}/ports/mini")
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/^mini\s+git\s+(?:\d+-\d+-\d+\s+\d+:\d+:\d+\s+)?#{quoted}/) }
-  its(:stdout) { should match(/^vagrant\s+-\s+#{Regexp.escape("/usr/local/poudriere/ports/vagrant")}$/) }
+  its(:stdout) { should match(/^vagrant\s+-\s+#{Regexp.escape("/home/vagrant/freebsd-ports")}$/) }
   its(:stderr) { should match(/^$/) }
 end
 

--- a/tests/serverspec/remove.yml
+++ b/tests/serverspec/remove.yml
@@ -10,6 +10,7 @@
     - command: poudriere ports -c -p mini -m git -B 20170222
     - command: poudriere jails -c -j 10_3 -m http -v 10.3-RELEASE
   roles:
+    - name: reallyenglish.git
     - ansible-role-poudriere
   vars:
     poudriere_config:


### PR DESCRIPTION
instead of installing `git` in the role, use `ansible-role-git`. the dependency is soft because the bundled `svn` client is the default and `git` is optional.