### PR TITLE
[feature] support make.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ None
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `poudriere_conf` | path to `poudriere.conf` | `/usr/local/etc/poudriere.conf` |
+| `poudriere_conf_d` | path to `poudriere.d` directory | `/usr/local/etc/poudriere.d` |
 | `poudriere_config_default` | defaults for `poudriere_config` | see below |
 | `poudriere_config` | dict of config that overrides `poudriere_config_default` | `{}` |
 | `poudriere_ports` | see below | `{}` |
 | `poudriere_jails` | see below | `{}` |
 | `poudriere_hooks` | see below | `{}` |
+| `poudriere_make_conf_files` | see below | `[]` |
 | `poudriere_pkg_repo_signing_key` | content of key with which `poudriere` sign packages | `""` |
 
 ## `poudriere_config_default`
@@ -25,7 +27,7 @@ details.
 
 ```yaml
 poudriere_config_default:
-  FREEBSD_HOST: ftp://ftp.freebsd.org
+  FREEBSD_HOST: https://ftp.freebsd.org
   SVN_HOST: svn.FreeBSD.org
   BASEFS: /usr/local/poudriere
   RESOLV_CONF: /etc/resolv.conf
@@ -62,6 +64,14 @@ poudriere_config_default:
 When `poudriere_pkg_repo_signing_key` is defined,
 `poudriere_config['PKG_REPO_SIGNING_KEY']` must be set to path to the key file.
 
+## `poudriere_make_conf_files`
+
+| Key | Description | Mandatory? |
+|-----|-------------|------------|
+| `name` | file name of the `make.conf(5)` | yes | 
+| `state` | create the file if `present`, remove it if `absent` | yes |
+| `content` | the content of the `make.conf(5)` | yes if `state` is `present` |
+
 # Dependencies
 
 None
@@ -74,8 +84,14 @@ None
     - name: reallyenglish.git
     - ansible-role-poudriere
   vars:
+    poudriere_make_conf_files:
+      - name: make.conf
+        state: present
+        content: |
+          LICENSES_ACCEPTED=MSPAT OSI
+          MAKE_JOB_NUMBERS=3
     poudriere_config:
-      FREEBSD_HOST: ftp://ftp.jp.freebsd.org
+      FREEBSD_HOST: http://ftp.freebsd.org
       NO_ZFS: "yes"
       GIT_URL: "https://github.com/reallyenglish/freebsd-ports-mini.git"
       CHECK_CHANGED_OPTIONS: verbose

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ When `poudriere_pkg_repo_signing_key` is defined,
 
 ## `poudriere_make_conf_files`
 
+This variable is a list of dict. Keys in items are described below.
+
 | Key | Description | Mandatory? |
 |-----|-------------|------------|
 | `name` | file name of the `make.conf(5)` | yes | 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,10 @@
 # devs said that "it's because you should not use it".
 # https://github.com/freebsd/poudriere/issues/333
 # poudriere_service: poudriered
-poudriere_conf: "/usr/local/etc/poudriere.conf"
+poudriere_conf: /usr/local/etc/poudriere.conf
+poudriere_conf_d: /usr/local/etc/poudriere.d
 poudriere_config_default:
-  FREEBSD_HOST: ftp://ftp.freebsd.org
+  FREEBSD_HOST: http://ftp.freebsd.org
   SVN_HOST: svn.FreeBSD.org
   BASEFS: /usr/local/poudriere
   RESOLV_CONF: /etc/resolv.conf
@@ -14,4 +15,5 @@ poudriere_config: {}
 poudriere_ports: {}
 poudriere_jails: {}
 poudriere_hooks: {}
+poudriere_make_conf_files: []
 poudriere_pkg_repo_signing_key: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,15 @@
       - poudriere_config_default.DISTFILES_CACHE | length > 0
     msg: "poudriere_config_default must have valid BASEFS and DISTFILES_CACHE"
 
+- name: Assert items in poudriere_make_conf_files have `name` as key
+  assert:
+    msg: items in poudriere_make_conf_files must have `name` as key
+    that:
+      - "'name' in item"
+      - item.name  is defined
+      - item.name | length > 0
+  with_items: "{{ poudriere_make_conf_files }}"
+
 - name: Assert items in poudriere_make_conf_files have either present or absent in key `state`
   assert:
     msg: item in poudriere_make_conf_files must have `state` as key and its value must be either `present` or `absent`
@@ -21,6 +30,15 @@
       - "'state' in item"
       - "item.state == 'present' or item.state == 'absent'"
   with_items: "{{ poudriere_make_conf_files }}"
+
+- name: Assert items with state `present` have `content` key
+  assert:
+    that:
+      - "'content' in item"
+      - item.content is defined
+  with_items: "{{ poudriere_make_conf_files }}"
+  when:
+    - "item.state == 'present'"
 
 - set_fact:
     poudriere_config_merged: "{{ poudriere_config_default | combine(poudriere_config, recursive = True) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,15 +14,45 @@
       - poudriere_config_default.DISTFILES_CACHE | length > 0
     msg: "poudriere_config_default must have valid BASEFS and DISTFILES_CACHE"
 
+- name: Assert items in poudriere_make_conf_files have either present or absent in key `state`
+  assert:
+    msg: item in poudriere_make_conf_files must have `state` as key and its value must be either `present` or `absent`
+    that:
+      - "'state' in item"
+      - "item.state == 'present' or item.state == 'absent'"
+  with_items: "{{ poudriere_make_conf_files }}"
+
 - set_fact:
     poudriere_config_merged: "{{ poudriere_config_default | combine(poudriere_config, recursive = True) }}"
 
 - include: install-{{ ansible_os_family }}.yml
 
+- name: Create poudriere_conf_d
+  file:
+    dest: "{{ poudriere_conf_d }}"
+    state: directory
+    mode: 0755
+
 - name: Create poudriere.conf
   template:
     src: poudriere.conf.j2
     dest: "{{ poudriere_conf }}"
+
+- name: Create make.conf files
+  template:
+    src: make.conf.j2
+    dest: "{{ poudriere_conf_d }}/{{ item.name }}"
+  with_items: "{{ poudriere_make_conf_files }}"
+  when:
+    - "item.state == 'present'"
+
+- name: Remove make.conf files
+  file:
+    dest: "{{ poudriere_conf_d }}/{{ item.name }}"
+    state: absent
+  with_items: "{{ poudriere_make_conf_files }}"
+  when:
+    - "item.state == 'absent'"
 
 - name: Assert poudriere_pkg_repo_signing_key is defined when PKG_REPO_SIGNING_KEY is defined
   assert:
@@ -51,7 +81,7 @@
 - name: Create hooks
   template:
     src: hook.sh.j2
-    dest: "/usr/local/etc/poudriere.d/hooks/{{ item.key }}.sh"
+    dest: "{{ poudriere_conf_d }}/hooks/{{ item.key }}.sh"
     mode: 0755
     validate: sh -n %s
   with_dict: "{{ poudriere_hooks }}"

--- a/templates/make.conf.j2
+++ b/templates/make.conf.j2
@@ -1,0 +1,2 @@
+# Managed by ansible
+{{ item.content }}

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -3,8 +3,14 @@
     - name: reallyenglish.git
     - ansible-role-poudriere
   vars:
+    poudriere_make_conf_files:
+      - name: make.conf
+        state: present
+        content: |
+          LICENSES_ACCEPTED=MSPAT OSI
+          MAKE_JOB_NUMBERS=3
     poudriere_config:
-      FREEBSD_HOST: ftp://ftp.jp.freebsd.org
+      FREEBSD_HOST: http://ftp.freebsd.org
       NO_ZFS: "yes"
       GIT_URL: "https://github.com/reallyenglish/freebsd-ports-mini.git"
       CHECK_CHANGED_OPTIONS: verbose

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -3,6 +3,7 @@ require "serverspec"
 
 package = "poudriere"
 config  = "/usr/local/etc/poudriere.conf"
+conf_d = "/usr/local/etc/poudriere.d"
 basefs = "/usr/local/poudriere"
 jail_hook_files = %w(jail.sh builder.sh)
 default_owner = "root"
@@ -13,6 +14,23 @@ key_file = "#{key_dir}/my.key"
 
 describe package(package) do
   it { should be_installed }
+end
+
+describe file(conf_d) do
+  it { should be_directory }
+  it { should be_owned_by default_owner }
+  it { should be_grouped_into default_group }
+  it { should be_mode 755 }
+end
+
+describe file("#{conf_d}/make.conf") do
+  it { should exist }
+  it { should be_file }
+  it { should be_owned_by default_owner }
+  it { should be_grouped_into default_group }
+  it { should be_mode 644 }
+  its(:content) { should match(/^LICENSES_ACCEPTED=MSPAT OSI$/) }
+  its(:content) { should match(/^MAKE_JOB_NUMBERS=3$/) }
 end
 
 describe file(basefs) do
@@ -54,7 +72,7 @@ describe file(config) do
   it { should be_mode 644 }
   its(:content) { should match(/NO_ZFS="yes"/) }
   its(:content) { should match(Regexp.escape('GIT_URL="https://github.com/reallyenglish/freebsd-ports-mini.git"')) }
-  its(:content) { should match(Regexp.escape('FREEBSD_HOST="ftp://ftp.jp.freebsd.org"')) }
+  its(:content) { should match(Regexp.escape('FREEBSD_HOST="http://ftp.freebsd.org"')) }
   its(:content) { should match(Regexp.escape('PKG_REPO_SIGNING_KEY="/usr/local/etc/poudriere/keys/my.key"')) }
 end
 

--- a/tests/serverspec/remove.yml
+++ b/tests/serverspec/remove.yml
@@ -1,6 +1,13 @@
 - hosts: localhost
   pre_tasks:
     - shell: (echo GIT_URL=https://github.com/reallyenglish/freebsd-ports-mini.git; echo BASEFS=/usr/local/poudriere; echo DISTFILES_CACHE=/usr/ports/distfiles) | tee -a /usr/local/etc/poudriere.conf
+    - file:
+        dest: "{{ poudriere_conf_d }}"
+        mode: 0755
+        state: directory
+    - copy:
+        dest: "{{ poudriere_conf_d  }}/make.conf"
+        content: "FOO=bar"
     - pkgng:
         name: "{{ item }}"
         state: present
@@ -14,7 +21,7 @@
     - ansible-role-poudriere
   vars:
     poudriere_config:
-      FREEBSD_HOST: ftp://ftp.jp.freebsd.org
+      FREEBSD_HOST: http://ftp.freebsd.org
       NO_ZFS: "yes"
       GIT_URL: "https://github.com/reallyenglish/freebsd-ports-mini.git"
       CHECK_CHANGED_OPTIONS: verbose
@@ -26,4 +33,7 @@
         state: absent
     poudriere_jails:
       "10_3":
+        state: absent
+    poudriere_make_conf_files:
+      - name: make.conf
         state: absent

--- a/tests/serverspec/remove_spec.rb
+++ b/tests/serverspec/remove_spec.rb
@@ -4,6 +4,7 @@ require "serverspec"
 package = "poudriere"
 config  = "/usr/local/etc/poudriere.conf"
 basefs = "/usr/local/poudriere"
+conf_d = "/usr/local/etc/poudriere.d"
 default_owner = "root"
 default_group = "wheel"
 distfiles = "/usr/ports/distfiles"
@@ -33,7 +34,7 @@ describe file(config) do
   it { should be_mode 644 }
   its(:content) { should match(/NO_ZFS="yes"/) }
   its(:content) { should match(Regexp.escape('GIT_URL="https://github.com/reallyenglish/freebsd-ports-mini.git"')) }
-  its(:content) { should match(Regexp.escape('FREEBSD_HOST="ftp://ftp.jp.freebsd.org"')) }
+  its(:content) { should match(Regexp.escape('FREEBSD_HOST="http://ftp.freebsd.org"')) }
 end
 
 describe command("poudriere ports -l") do
@@ -49,5 +50,9 @@ describe command("poudriere jails -l") do
 end
 
 describe file("#{basefs}/ports/mini") do
+  it { should_not exist }
+end
+
+describe file("#{conf_d}/make.conf") do
   it { should_not exist }
 end


### PR DESCRIPTION
support `make.conf(5)`

also,

* improve network-compatibility by replacing `ftp:` with `http:`
* introduce `poudriere_conf_d`, removing hard-coded path
