### PR TITLE
Release 1.5.0

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,7 +19,6 @@ provisioner:
   additional_copy_path:
     - extra_modules
     - filter_plugins
-  ansible_vault_password_file: <%= File.expand_path(ENV['ANSIBLE_VAULT_PASSWORD_FILE'] || '') %>
 
 platforms:
   - name: freebsd-11.1-amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release 1.5.0
+
+* 8c93b33 [feature] allow other package name than poudriere (#26)
+
 ## Release 1.4.0
 
 * c5d2a7e [feature] Support CCACHE_DIR (#24)


### PR DESCRIPTION
@mitsururike @supachots Release 1.5.0

also, remove ansible_vault_password_file from .kitchen.yml
see https://github.com/reallyenglish/ansible-role-zsh/pull/6 for the
reason.